### PR TITLE
Fixed the module version for product recommendations

### DIFF
--- a/01_ProductRecommendations/bedrock-text-search.ipynb
+++ b/01_ProductRecommendations/bedrock-text-search.ipynb
@@ -76,6 +76,7 @@
    "outputs": [],
    "source": [
     "# Install all the required prerequiste libraries - approx 3 min to complete\n",
+    "%pip install setuptools==65.5.0",
     "%pip install -U pgvector pandarallel boto3 psycopg numexpr"
    ]
   },

--- a/01_ProductRecommendations/bedrock-text-search.ipynb
+++ b/01_ProductRecommendations/bedrock-text-search.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "# Install all the required prerequiste libraries - approx 3 min to complete\n",
-    "%pip install setuptools==65.5.0",
+    "%pip install setuptools==65.5.0\n",
     "%pip install -U pgvector pandarallel boto3 psycopg numexpr"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
The python module import was failing due to setuptools version difference.

*Description of changes:*
Fixed the import issue by fixing the setuptools version which is compatible to pandaparallel. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
